### PR TITLE
Fix about section certificate link to portfolio

### DIFF
--- a/src/Pages/About.jsx
+++ b/src/Pages/About.jsx
@@ -179,7 +179,18 @@ const AboutPage = () => {
 
   // Click handler for stat cards
   const handleStatClick = (link) => {
-    if (link) {
+    if (link === "#Certificates") {
+      // First scroll to Portfolio section
+      const portfolioSection = document.querySelector("#Portfolio");
+      if (portfolioSection) {
+        portfolioSection.scrollIntoView({ behavior: "smooth" });
+        // Wait a bit for scroll to complete, then trigger certificate tab
+        setTimeout(() => {
+          // Dispatch a custom event to switch to certificates tab
+          window.dispatchEvent(new CustomEvent('switchToCertificates'));
+        }, 500);
+      }
+    } else if (link) {
       const section = document.querySelector(link);
       if (section) {
         section.scrollIntoView({ behavior: "smooth" });

--- a/src/Pages/Portofolio.jsx
+++ b/src/Pages/Portofolio.jsx
@@ -63,6 +63,19 @@ export default function FullWidthTabs() {
     onSwipedRight: () => setValue((prev) => Math.max(prev - 1, 0)),
   });
 
+  // Listen for custom event to switch to certificates tab
+  useEffect(() => {
+    const handleSwitchToCertificates = () => {
+      setValue(1); // Index 1 is the Certificates tab
+    };
+
+    window.addEventListener('switchToCertificates', handleSwitchToCertificates);
+    
+    return () => {
+      window.removeEventListener('switchToCertificates', handleSwitchToCertificates);
+    };
+  }, []);
+
   return (
     <div {...handlers} className="md:px-[10%] px-[5%] w-full sm:mt-0 mt-[3rem] bg-[#030014] overflow-hidden" id="Portfolio">
       <Box sx={{ width: "100%" }}>


### PR DESCRIPTION
Enable navigation from About section's 'Certificates' box to the 'Certificates' tab in the Portfolio section.

The application is a single-page layout where About and Portfolio sections reside on the same route. This PR implements a custom event system to scroll to the Portfolio section and then programmatically switch to the 'Certificates' tab, ensuring correct navigation within the existing structure.

---

[Open in Web](https://cursor.com/agents?id=bc-94f80f1b-0d8e-4ef0-9a85-90ca06d6d611) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-94f80f1b-0d8e-4ef0-9a85-90ca06d6d611) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)